### PR TITLE
Testing: Add rspec fixtures and test api endpoints with valid token

### DIFF
--- a/hawk/spec/controllers/api/v1/cluster_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/cluster_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::ClusterController do
 
   context 'without a valid token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = ""
       get 'index'
     end
@@ -18,6 +19,7 @@ RSpec.describe Api::V1::ClusterController do
 
   context 'with a fake token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token token_string"
       get 'index'
     end
@@ -31,8 +33,7 @@ RSpec.describe Api::V1::ClusterController do
 
   context 'with a valid token' do
     before do
-      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
-      allow(File).to receive(:open).and_return(fake_yaml_store)
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token a123456789"
       get 'index'
     end

--- a/hawk/spec/controllers/api/v1/cluster_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/cluster_controller_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe Api::V1::ClusterController do
     end
   end
 
+
+
+  context 'with a valid token' do
+    before do
+      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
+      allow(File).to receive(:open).and_return(fake_yaml_store)
+      @request.headers['Authorization'] = "Token a123456789"
+      get 'index'
+    end
+
+    it 'it returns a response with 200 status code' do
+      expect(response).to have_http_status 200
+    end
+  end
+
 end

--- a/hawk/spec/controllers/api/v1/nodes_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/nodes_controller_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe Api::V1::NodesController do
     end
   end
 
+
+
+  context 'with a valid token' do
+    before do
+      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
+      allow(File).to receive(:open).and_return(fake_yaml_store)
+      @request.headers['Authorization'] = "Token a123456789"
+      get 'index'
+    end
+
+    it 'it returns a response with 200 status code' do
+      expect(response).to have_http_status 200
+    end
+  end
+
 end

--- a/hawk/spec/controllers/api/v1/nodes_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/nodes_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::NodesController do
 
   context 'without a valid token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = ""
       get 'index'
     end
@@ -18,6 +19,7 @@ RSpec.describe Api::V1::NodesController do
 
   context 'with a fake token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token token_string"
       get 'index'
     end
@@ -31,8 +33,7 @@ RSpec.describe Api::V1::NodesController do
 
   context 'with a valid token' do
     before do
-      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
-      allow(File).to receive(:open).and_return(fake_yaml_store)
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token a123456789"
       get 'index'
     end

--- a/hawk/spec/controllers/api/v1/resources_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/resources_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::ResourcesController do
 
   context 'without a valid token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = ""
       get 'index'
     end
@@ -18,6 +19,7 @@ RSpec.describe Api::V1::ResourcesController do
 
   context 'with a fake token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token token_string"
       get 'index'
     end
@@ -31,8 +33,7 @@ RSpec.describe Api::V1::ResourcesController do
 
   context 'with a valid token' do
     before do
-      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
-      allow(File).to receive(:open).and_return(fake_yaml_store)
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token a123456789"
       get 'index'
     end

--- a/hawk/spec/controllers/api/v1/resources_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/resources_controller_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe Api::V1::ResourcesController do
     end
   end
 
+
+
+  context 'with a valid token' do
+    before do
+      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
+      allow(File).to receive(:open).and_return(fake_yaml_store)
+      @request.headers['Authorization'] = "Token a123456789"
+      get 'index'
+    end
+
+    it 'it returns a response with 200 status code' do
+      expect(response).to have_http_status 200
+    end
+  end
+
 end

--- a/hawk/spec/controllers/api/v1/status_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/status_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::StatusController do
 
   context 'without a valid token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = ""
       get 'index'
     end
@@ -18,6 +19,7 @@ RSpec.describe Api::V1::StatusController do
 
   context 'with a fake token' do
     before do
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token token_string"
       get 'index'
     end
@@ -31,8 +33,7 @@ RSpec.describe Api::V1::StatusController do
 
   context 'with a valid token' do
     before do
-      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
-      allow(File).to receive(:open).and_return(fake_yaml_store)
+      pass_fake_yaml_store
       @request.headers['Authorization'] = "Token a123456789"
       get 'index'
     end

--- a/hawk/spec/controllers/api/v1/status_controller_spec.rb
+++ b/hawk/spec/controllers/api/v1/status_controller_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe Api::V1::StatusController do
     end
   end
 
+
+
+  context 'with a valid token' do
+    before do
+      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
+      allow(File).to receive(:open).and_return(fake_yaml_store)
+      @request.headers['Authorization'] = "Token a123456789"
+      get 'index'
+    end
+
+    it 'it returns a response with 200 status code' do
+      expect(response).to have_http_status 200
+    end
+  end
+
 end

--- a/hawk/spec/fixtures/files/api_token_dummy.store
+++ b/hawk/spec/fixtures/files/api_token_dummy.store
@@ -1,0 +1,5 @@
+---
+hacluster: !ruby/struct:Struct::ApiToken
+  username: hacluster
+  api_token: a123456789
+  expires: 2388665373

--- a/hawk/spec/spec_helper.rb
+++ b/hawk/spec/spec_helper.rb
@@ -16,6 +16,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require './spec/support/helpers/api'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -39,6 +41,9 @@ RSpec.configure do |config|
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
+
+  # Include the api helpers to all of our api rspecs
+  config.include Helpers::ApiHelpers
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/hawk/spec/support/helpers/api.rb
+++ b/hawk/spec/support/helpers/api.rb
@@ -1,0 +1,8 @@
+module Helpers
+  module ApiHelpers
+    def pass_fake_yaml_store
+      fake_yaml_store = YAML.load_file(file_fixture("api_token_dummy.store"))
+      allow(File).to receive(:open).and_return(fake_yaml_store)
+    end
+  end
+end


### PR DESCRIPTION
I added fixtures to rspec. So now we can pass a dummy yaml file to the api controller when we test certain things. So test's are not dependent on the individual or not existing yaml store.